### PR TITLE
Add PageGuard to Analytics tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Curated list of resources to start and grow your startup
 - [Hotjar - Heatmaps, Visitor Recordings, Conversion Funnels, Form Analytics, Feedback Polls and Surveys in One Platform](https://www.hotjar.com/)
 - [Google Analytics](https://analytics.google.com/analytics/web/)
 - [Microsoft Clarity - Free Heatmaps & Session Recordings](https://clarity.microsoft.com/)
+- [PageGuard - Free website health scanner: SEO, accessibility (ADA/WCAG) & Core Web Vitals](https://pageguard.org)
 
 ## Task & Project Management
 - [Todoist](https://todoist.com/)


### PR DESCRIPTION
Adding [PageGuard](https://pageguard.org) to the Analytics section — a free website health scanner that checks SEO, accessibility (WCAG 2.1/ADA compliance), Core Web Vitals performance, and best practices in 30 seconds.

**Why it fits the Analytics section:**
- Free tier, no sign-up required for quick scans
- Provides actionable health scores across 4 dimensions
- Particularly relevant given the ADA Title II compliance deadline (April 24, 2026)
- Used by small businesses, designers, and marketing agencies to monitor their websites

Complements existing tools like Google Analytics (traffic) and Hotjar (behavior) with technical health monitoring.