### PR TITLE
Add EnrichAnything to market research tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Curated list of resources to start and grow your startup
 - [Aytm](https://aytm.com/)
 - [Similar Web](https://www.similarweb.com/pt)
 - [Compass](https://www.compass.co/)
+- [EnrichAnything](https://www.enrichanything.com/) - Turn public hiring, ecommerce, and GTM signals into usable company lists.
 
 ## Growth
 - [Beginners guide to seo](https://moz.com/beginners-guide-to-seo)


### PR DESCRIPTION
Adds EnrichAnything under Market Research.\n\nIt fits here as a tool for turning public hiring, ecommerce, and GTM signals into company lists for research and prospecting.