### PR TITLE
Add three free tools: Not Human Search (AI), 8bitconcepts Research (Market Research), AI Dev Jobs (Hiring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Curated list of resources to start and grow your startup
 
 ## AI
 - [ChatGPT](https://chatgpt.com/)
+- [Not Human Search](https://nothumansearch.ai/) - Agent-first search engine indexing MCP servers, agent-readable APIs, and llms.txt sites. Free REST API and MCP server. Useful when your AI assistant needs to discover tools and integrations. MIT licensed.
 
 
 ## Marketing
@@ -258,6 +259,7 @@ Curated list of resources to start and grow your startup
 - [Aytm](https://aytm.com/)
 - [Similar Web](https://www.similarweb.com/pt)
 - [Compass](https://www.compass.co/)
+- [8bitconcepts Research](https://8bitconcepts.com/) - Independent weekly research on enterprise AI adoption: agentic accountability, hallucination budgets, governance gaps, integration tax. Free, no sponsors, RSS feed. Useful for founders making build-vs-buy decisions on AI.
 
 ## Growth
 - [Beginners guide to seo](https://moz.com/beginners-guide-to-seo)
@@ -267,3 +269,4 @@ Curated list of resources to start and grow your startup
 ## Hiring
 - [Founder library about hiring](https://www.founderlibrary.com/categories/hiring)
 - [Job Interviews Don't Work](https://fs.blog/2020/07/job-interviews/)
+- [AI Dev Jobs](https://aidevboard.com/) - Job board with 8,400+ AI/ML engineering roles from 489 companies. Free REST API and MCP server for programmatic sourcing. Helpful for startups hiring ML, LLM, and AI engineers.


### PR DESCRIPTION
Three free, open resources for different tool subsections of the list. Each is genuinely useful to startup founders and fits a distinct section.

### `## AI`
**[Not Human Search](https://nothumansearch.ai/)** — agent-first search engine indexing MCP servers, agent-readable APIs, and `llms.txt` sites. Free REST API and MCP server. Useful when a founder's AI assistant or Claude/Cursor workflow needs to discover tools and integrations. MIT licensed.

### `## Market Research`
**[8bitconcepts Research](https://8bitconcepts.com/)** — independent weekly research on enterprise AI adoption covering agentic accountability, hallucination budgets, governance gaps, and the integration tax. Free, no sponsors, RSS feed. Useful for founders making build-vs-buy decisions on AI and sizing LLM-related risk.

### `## Hiring`
**[AI Dev Jobs](https://aidevboard.com/)** — job board with 8,400+ AI/ML engineering roles from 489 companies. Free REST API and MCP server so startups can pull ML/LLM candidate pipelines programmatically. Free for employers to post.

All three are live products with public pricing (free tiers available), first-party canonical domains, and no affiliate links. Alphabetized where each section is alphabetized, appended where it isn't.