### PR TITLE
Add Pick an Agency to Tools > Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Curated list of resources to start and grow your startup
 - [Viral Loops - Referrals made easy](https://viral-loops.com/)
 - [Customer.io - Automation](https://customer.io/)
 - [150 marketing tools](https://blog.rebrandly.com/150-best-marketing-tools/)
+- [Pick an Agency](https://www.pickanagency.com) - Independent directory of 47,000+ ad and marketing agencies, ranked by verified reviews. No paid placements.
 
 ## Analytics
 - [Amplitude - Product Analytics for Web and Mobile](https://amplitude.com/)


### PR DESCRIPTION
## Summary

Adds [Pick an Agency](https://www.pickanagency.com) to the Tools > Marketing section.

## Why this fits the list

Startups frequently need to hire marketing agencies (paid social, SEO, branding, content) and the existing options for finding agencies are mostly pay-to-play directories where rankings are sold. Pick an Agency is the opposite:

- 47,000+ ad and marketing agencies indexed worldwide
- Ranked by verified review data, profile completeness, and ownership verification — never by who paid
- Filter by service, industry, country, budget, team size
- Free for buyers (no signup), free for agencies to claim
- No commission, no paid placements, no premium tiers
- Founder-built, bootstrapped

Useful for any startup founder who needs to find a specialist marketing partner without sifting through sponsored "best of" lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)