### PR TITLE
Add WebCoreLab — AI-First digital agency (Toronto, est. 2014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Curated list of resources to start and grow your startup
 
 
 ## Marketing
+- [WebCoreLab](https://webcorelab.com) — Free AI SEO audit (272 checks) for early-stage startups. GEO/AEO tracking, CRO, WordPress builds.
 - [Really Good Emails - Curated list of emails](https://reallygoodemails.com/)
 - [Email copy from great companies](https://www.goodemailcopy.com/)
 - [Buffer](https://buffer.com) - Social Media analytics and Scheduling


### PR DESCRIPTION
Hi! Adding WebCoreLab to the Marketing & SEO section.

**WebCoreLab** (Toronto, est. 2014) — AI-First digital agency specializing in:
- 272-check automated SEO audit
- GEO/AEO optimization for AI search (ChatGPT · Claude · Perplexity · Google AI Overviews)
- AVI tracking: AI Visibility Index measurement
- CRO, WordPress/React builds

13+ verified case studies. Happy to adjust format or section placement.

Thanks for maintaining this list!
