### PR TITLE
Add LLC Class — Wyoming LLC formation for non-US founders

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Curated list of resources to start and grow your startup.
 - [Stripe Atlas](https://stripe.com/atlas) — Incorporate a US company (Delaware) fully online
 - [Clerky](https://www.clerky.com/) — Legal documents for startups: incorporation, SAFEs, offer letters
 - [Doola](https://www.doola.com/) — Incorporation + US bank account for international founders
+- [LLC Class](https://llcclass.com) — Wyoming LLC formation for non-US founders: state filing, registered agent, EIN application, BOI compliance, and privacy-friendly rules. No US address needed.
 - [Cooley GO](https://www.cooleygo.com/) — Free legal documents and resources for startups
 - [Vanta](https://www.vanta.com/) — Automate SOC 2, ISO 27001, HIPAA, and GDPR compliance
 - [Drata](https://drata.com/) — Continuous compliance automation with a public Trust Center to close enterprise deals


### PR DESCRIPTION
## What is LLC Class?

[LLC Class](https://llcclass.com) is a concierge Wyoming LLC formation service for non-US founders and global entrepreneurs. It handles:

- State filing with Wyoming Secretary of State
- Registered agent service (required by Wyoming)
- EIN application guidance (no US address needed)
- BOI report filing with FinCEN
- Operating agreement and ongoing annual compliance

## Why it belongs in this section

The repo already lists [Doola](https://doola.com) for non-US founders forming a US company. LLC Class is a direct alternative specifically focused on **Wyoming** LLC formation — which is the most popular structure for non-US residents due to Wyoming's strong asset protection laws, zero state income tax, and privacy-friendly rules.

- 4.9/5 on Trustpilot
- 100,000+ customers served
- Available for founders from 50+ countries
- Featured on NBC, FOX, CBS