### PR TITLE
Add AiToolsObserver to places to post your startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Curated list of resources to start and grow your startup.
 
 # Places to post your startup
 
+- [AiToolsObserver](https://aitoolsobserver.com/) — AI discovery platform that accepts free AI tool submissions and publishes comparisons, trends and practical use cases
 - [Curated List](https://github.com/mmccaff/PlacesToPostYourStartup)
 - [BetaPage](https://betapage.co/)
 - [Product Hunt](http://www.producthunt.com/)


### PR DESCRIPTION
## What changed

Adds AiToolsObserver to **Places to post your startup**.

AiToolsObserver is an AI discovery platform that accepts free AI tool submissions and publishes comparisons, trend coverage, and practical use cases for AI adopters.

## Disclosure

I am affiliated with AiToolsObserver. The entry is limited to one factual line in the relevant existing category.

## Validation

- Confirmed the website is live and actively maintained
- Checked that the URL is not already listed
- Ran `git diff --check`