### PR TITLE
Add AnswerLens to SEO & Growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Curated list of resources to start and grow your startup.
 - [Google Search Console](https://search.google.com/search-console/) — Free SEO monitoring from Google
 - [Screaming Frog](https://www.screamingfrog.co.uk/seo-spider/) — Technical SEO site auditor
 - [Ubersuggest](https://neilpatel.com/ubersuggest/) — Accessible keyword research tool
+- [AnswerLens](https://app.sfdj.net/) — Audits B2B SaaS public website evidence for pricing, proof, docs, comparison, trust, schema, and llms.txt gaps
 
 ## Naming
 


### PR DESCRIPTION
Adds AnswerLens to Tools > SEO & Growth.

Why it fits:

- The list includes startup tools for SEO, growth, analytics, marketing, and market research.
- AnswerLens gives B2B SaaS founders and growth teams a free public-evidence scan and a paid implementation report path for visible website gaps.

Disclosure: I am connected to AnswerLens.

Boundary: This is a factual startup-resource entry. It does not claim rankings, AI citations, traffic, conversions, revenue, sponsorship, affiliate relationship, or any guaranteed outcome.