### PR TITLE
Add WP Goldmine to Market Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ Curated list of resources to start and grow your startup.
 - [Aytm](https://aytm.com/)
 - [Similar Web](https://www.similarweb.com/pt)
 - [Compass](https://www.compass.co/)
+- [WP Goldmine](https://wpgoldmine.io) — Market research for WordPress: finds abandoned or unsupported plugins that still have large active-install bases, surfacing product gaps you could rebuild and capture.
 
 ## Research
 


### PR DESCRIPTION
Adds **WP Goldmine** to the Market Research section.

It's a market-research tool for the WordPress ecosystem: it finds abandoned, low-rated, or unsupported plugins that still have large active-install bases — surfacing validated product gaps a maker could rebuild and capture. Fits alongside the other market-research/opportunity-sizing tools in this section.

Disclosure: I'm the maintainer of this tool.