### PR TITLE
Add Klinky

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Curated list of resources to start and grow your startup.
 - [Sumo](https://page.sumo.com/gosumo) — Email capture and traffic growth tools
 - [Viral Loops](https://viral-loops.com/) — Referral programs made easy
 - [Customer.io](https://customer.io/) — Behavioral email and messaging automation
+- [Klinky](https://klinky.io) — A/B testing link shortener: split one link between two destinations for controlled rollouts. Free tier available
 - [150 marketing tools](https://blog.rebrandly.com/150-best-marketing-tools/)
 
 ## Email Marketing


### PR DESCRIPTION
Adds [Klinky](https://klinky.io) to the Tools > Marketing section.

Klinky is an A/B testing link shortener: one short link splits traffic between two destinations at adjustable weights, so a startup can send a controlled share of visitors to a new landing page, offer, or workflow and compare results with real data. Fits the Marketing tools section alongside conversion/growth tools like Viral Loops and Sumo. Free tier available.