### PR TITLE
Add Translation & Localization section with Alconost and Nitro

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,11 @@ Curated list of resources to start and grow your startup.
 - [150 marketing tools](https://blog.rebrandly.com/150-best-marketing-tools/)
 - [Pick an Agency](https://www.pickanagency.com) - Independent directory of 47,000+ ad and marketing agencies, ranked by verified reviews. No paid placements.
 
+## Translation & Localization
+
+- [Alconost](https://alconost.com) — Full-stack localization for software, games, and marketing content. 120+ languages, human + AI-enhanced workflows.
+- [Nitro](https://nitrotranslate.com) — Self-service human translation API. AI agents can autonomously order and pay for translations via the Machine Payments Protocol (MPP).
+
 ## Email Marketing
 
 - [Mailchimp](https://mailchimp.com/) — Most popular email marketing platform


### PR DESCRIPTION
Adds a new Translation & Localization section for startups going global. When expanding internationally, startups need translation and localization services for websites, apps, marketing content, and customer support. Two entries added: Alconost (full-stack localization) and Nitro (self-service human translation API).